### PR TITLE
Small modification to parse history files

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -36,9 +36,9 @@ type Revision struct {
 
 // A wiki page.
 type Page struct {
-	Title    string   `xml:"title"`
-	ID       uint64   `xml:"id"`
-	Revision []Revision `xml:"revision"`
+	Title     string     `xml:"title"`
+	ID        uint64     `xml:"id"`
+	Revisions []Revision `xml:"revision"`
 }
 
 // That which emits wiki pages.


### PR DESCRIPTION
Changing "Revision Revision" for "Revisions []Revision" in the Page structure allows to load many versions of each article when parsing dumps that contain the whole history. The change will break code depending on this project.
